### PR TITLE
Limit FPS to consume less CPU.

### DIFF
--- a/cyclops.py
+++ b/cyclops.py
@@ -78,6 +78,7 @@ lowerLidEdgePts   = get_points(dom, "lowerLidEdge"  , 33, False, False)
 
 DISPLAY = pi3d.Display.create(samples=4)
 DISPLAY.set_background(0, 0, 0, 1) # r,g,b,alpha
+DISPLAY.frames_per_second = 30 # limit to 30 FPS
 
 # eyeRadius is the size, in pixels, at which the whole eye will be rendered.
 if DISPLAY.width <= (DISPLAY.height * 2):

--- a/eyes.py
+++ b/eyes.py
@@ -78,6 +78,7 @@ lowerLidEdgePts   = get_points(dom, "lowerLidEdge"  , 33, False, False)
 
 DISPLAY = pi3d.Display.create(samples=4)
 DISPLAY.set_background(0, 0, 0, 1) # r,g,b,alpha
+DISPLAY.frames_per_second = 30 # limit to 30 FPS
 
 # eyeRadius is the size, in pixels, at which the whole eye will be rendered
 # onscreen.  eyePosition, also pixels, is the offset (left or right) from


### PR DESCRIPTION
Currently the Pi3D loops are free running, so this PR limits them to 30 FPS to consume fewer CPU resources.

[Pi3D docs](https://pi3d.github.io/html/pi3d.html#pi3d.Display.Display.loop_running)