### PR TITLE
disable ADC

### DIFF
--- a/snake_eyes_bonnet.py
+++ b/snake_eyes_bonnet.py
@@ -14,8 +14,8 @@ import time
 from threading import Thread
 import board
 import busio
-import adafruit_ads1x15.ads1015 as ADS
-from adafruit_ads1x15.analog_in import AnalogIn
+#import adafruit_ads1x15.ads1015 as ADS
+#from adafruit_ads1x15.analog_in import AnalogIn
 
 class AdcChannel():
     """Corresponds to ONE CHANNEL of the Snake Eye Bonnet's ADS1015
@@ -77,12 +77,12 @@ class SnakeEyesBonnet(Thread):
        four channels of analog input with clipping and filtering, with
        output ranging from 0.0 to 1.0 (rather than specific voltages or
        integer units)."""
-    channel_dict = {
-        0: ADS.P0,
-        1: ADS.P1,
-        2: ADS.P2,
-        3: ADS.P3
-    }
+#    channel_dict = {
+#        0: ADS.P0,
+#        1: ADS.P1,
+#        2: ADS.P2,
+#        3: ADS.P3
+#    }
 
     def __init__(self, *args, **kwargs):
         """SnakeEyesBonnet constructor."""


### PR DESCRIPTION
The ADC feature does not have an easy override option. It has been preventing pi_eyes.py from running.

This is the error message that appears with a Pi3B running 2021-05-07-raspios-buster-armhf-lite with 1.4" 128x128 OLEDs. The above PR comments out a few lines of ADC initialization. Just a hack to make the code functional for most users.

```
$ cd /boot/Pi_Eyes;python3 eyes.py --radius 128 &
[2] 796
pi@pi3:/boot/Pi_Eyes $ Traceback (most recent call last):
  File "eyes.py", line 19, in <module>
    from snake_eyes_bonnet import SnakeEyesBonnet
  File "/boot/Pi_Eyes/snake_eyes_bonnet.py", line 17, in <module>
    import adafruit_ads1x15.ads1015 as ADS
  File "/usr/local/lib/python3.7/dist-packages/adafruit_ads1x15/ads1015.py", line 23, in <module>
    from .ads1x15 import ADS1x15, Mode
  File "/usr/local/lib/python3.7/dist-packages/adafruit_ads1x15/ads1x15.py", line 19, in <module>
    from adafruit_bus_device.i2c_device import I2CDevice
  File "/usr/local/lib/python3.7/dist-packages/adafruit_bus_device/i2c_device.py", line 15, in <module>
    from circuitpython_typing import ReadableBuffer, WriteableBuffer
  File "/usr/local/lib/python3.7/dist-packages/circuitpython_typing/__init__.py", line 79
    def read(self, count: Optional[int] = None, /) -> Optional[bytes]:
                                                ^
SyntaxError: invalid syntax
```

[Forum issue](https://forums.adafruit.com/viewtopic.php?t=210634) 